### PR TITLE
add spf macro expansion for ipv6 addresses

### DIFF
--- a/spf.go
+++ b/spf.go
@@ -831,7 +831,19 @@ func (r *resolution) expandMacros(s, domain string) (string, error) {
 			case "d":
 				str = domain
 			case "i":
-				str = r.ip.String()
+				// str = r.ip.String()
+				switch r.ip.To4() {
+				case nil: // ipv6
+					// expand the ipv6 address to it's full dotted representation.
+					var sb strings.Builder
+					sb.Grow(64)
+					for _, b := range r.ip.To16() {
+						fmt.Fprintf(&sb, ".%x.%x", b>>4, b&0b1111)
+					}
+					str = sb.String()
+				default: // ipv4
+					str = r.ip.String()
+				}
 			case "p":
 				// This shouldn't be used, we don't want to support it, it's
 				// risky. "unknown" is a safe value.

--- a/spf_test.go
+++ b/spf_test.go
@@ -350,12 +350,14 @@ func TestMacros(t *testing.T) {
 		{"v=spf1 +a:vvv-%{v}-vvv", Pass, errMatchedA},
 		{"v=spf1 a:%{x}", PermError, errInvalidMacro},
 		{"v=spf1 +a:ooo-%{o7}-ooo", Pass, errMatchedA},
+		{"v=spf1 exists:%{ir}.vvv -all", Pass, errMatchedExists},
 	}
 
 	dns.Ip["sss-user@domain-sss"] = []net.IP{ip6666}
 	dns.Ip["ooo-domain-ooo"] = []net.IP{ip6666}
 	dns.Ip["ppp-unknown-ppp"] = []net.IP{ip6666}
 	dns.Ip["vvv-ip6-vvv"] = []net.IP{ip6666}
+	dns.Ip["8.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.vvv"] = []net.IP{ip1111}
 
 	for _, c := range cases {
 		dns.Txt["domain"] = []string{c.txt}


### PR DESCRIPTION
Hello,

Thank you for creating a very usable SPF library.

We have found that there is a bug where you do not handle IPv6 macro's. I have expanded on the IPv4 capability to add the expansion of IPv6 out to full dotted format. This is useful for %{ir} macros with IPv6. In this use case we need to turn the compressed ipv6 format into the full dotted format address. When the address is resolved it is done so with an IN A lookup.