### PR TITLE
improved RFC support with addition of configurable void lookups count…

### DIFF
--- a/spf.go
+++ b/spf.go
@@ -107,11 +107,14 @@ var (
 	ErrMatchedExists = errors.New("matched exists")
 )
 
-// Default value for the maximum number of DNS lookups while resolving SPF.
-// RFC is quite clear 10 must be the maximum allowed.
-// https://tools.ietf.org/html/rfc7208#section-4.6.4
 const (
-	defaultMaxLookups     = 10
+	// Default value for the maximum number of DNS lookups while resolving SPF.
+	// RFC is quite clear 10 must be the maximum allowed.
+	// https://tools.ietf.org/html/rfc7208#section-4.6.4
+	defaultMaxLookups = 10
+	// Default value for the maximum number of DNS void lookups while resolving SPF.
+	// RFC suggests that implementations SHOULD limit these with a configurable default of 2.
+	// https://tools.ietf.org/html/rfc7208#section-4.6.4
 	defaultMaxVoidLookups = 2
 )
 
@@ -202,11 +205,9 @@ func OverrideLookupLimit(limit uint) Option {
 	}
 }
 
-// OverrideVoidLookupLimit overrides the maximum number of void lookups allowed
-// during SPF evaluation. Note the RFC, SPF implementations SHOULD limit
-// "void lookups" to two.  An implementation MAY choose to make such a
-// limit configurable.  In this case, a default of two is RECOMMENDED.
-// Exceeding the limit produces a "permerror" result.
+// OverrideVoidLookupLimit overrides the maximum number of void DNS lookups allowed
+// during SPF evaluation. A void DNS lookup is one that returns an empty answer, or a "name error".
+// Note that as per RFC, the default value of 2 SHOULD be used. Please use with care.
 //
 // This is EXPERIMENTAL for now, and the API is subject to change.
 func OverrideVoidLookupLimit(limit uint) Option {

--- a/spf_test.go
+++ b/spf_test.go
@@ -526,13 +526,19 @@ func TestOverrideVoidLookupLimit(t *testing.T) {
 	dns := NewDefaultResolver()
 	defaultTrace = t.Logf
 
+	nxDomainErr := &net.DNSError{
+		Err:         "no such domain",
+		IsTemporary: false,
+		IsNotFound:  true,
+	}
+
 	dns.Txt["domain1"] = []string{"v=spf1 exists:%{i}.one include:domain2"}
 	dns.Txt["domain2"] = []string{"v=spf1 exists:%{i}.two include:domain3"}
 	dns.Txt["domain3"] = []string{"v=spf1 exists:%{i}.three include:domain4"}
 	dns.Txt["domain4"] = []string{"v=spf1 +all"}
-	dns.Errors["1.1.1.1.one"] = fmt.Errorf("no such domain")
-	dns.Errors["1.1.1.1.two"] = fmt.Errorf("no such domain")
-	dns.Errors["1.1.1.1.three"] = fmt.Errorf("no such domain")
+	dns.Errors["1.1.1.1.one"] = nxDomainErr
+	dns.Errors["1.1.1.1.two"] = nxDomainErr
+	dns.Errors["1.1.1.1.three"] = nxDomainErr
 
 	// The default of 2
 	res, err := CheckHostWithSender(ip1111, "helo", "user@domain1")

--- a/spf_test.go
+++ b/spf_test.go
@@ -522,6 +522,40 @@ func TestOverrideLookupLimit(t *testing.T) {
 	}
 }
 
+func TestOverrideVoidLookupLimit(t *testing.T) {
+	dns := NewDefaultResolver()
+	defaultTrace = t.Logf
+
+	dns.Txt["domain1"] = []string{"v=spf1 exists:%{i}.one include:domain2"}
+	dns.Txt["domain2"] = []string{"v=spf1 exists:%{i}.two include:domain3"}
+	dns.Txt["domain3"] = []string{"v=spf1 exists:%{i}.three include:domain4"}
+	dns.Txt["domain4"] = []string{"v=spf1 +all"}
+	dns.Errors["1.1.1.1.one"] = fmt.Errorf("no such domain")
+	dns.Errors["1.1.1.1.two"] = fmt.Errorf("no such domain")
+	dns.Errors["1.1.1.1.three"] = fmt.Errorf("no such domain")
+
+	// The default of 2
+	res, err := CheckHostWithSender(ip1111, "helo", "user@domain1")
+	if res != PermError {
+		t.Errorf("expected permerror, got %q / %q", res, err)
+	}
+
+	// Set the limit to 10, which is excessive.
+	res, err = CheckHostWithSender(ip1111, "helo", "user@domain1",
+		OverrideVoidLookupLimit(10))
+	if res != Pass {
+		t.Errorf("expected pass, got %q / %q", res, err)
+	}
+
+	// Set the limit to 1, which is not enough.
+	res, err = CheckHostWithSender(ip1111, "helo", "user@domain1",
+		OverrideVoidLookupLimit(1))
+	if res != PermError || err != ErrVoidLookupLimitReached {
+		t.Errorf("expected permerror/void lookup limit reached, got %q / %q",
+			res, err)
+	}
+}
+
 func TestWithContext(t *testing.T) {
 	dns := NewDefaultResolver()
 	defaultTrace = t.Logf


### PR DESCRIPTION
This pull request adds "void lookup" count checks. [RFC7204 Section 4.6.4](https://datatracker.ietf.org/doc/html/rfc7208#section-4.6.4 ) states the following

>   SPF implementations SHOULD limit
   "void lookups" to two.  An implementation MAY choose to make such a
   limit configurable.  In this case, a default of two is RECOMMENDED.
   Exceeding the limit produces a "permerror" result.

This PR adds the count check for that covers void lookups with the ability to override the configured default of 2. This follows the pattern of the other count override. At this point in time only macros will increment the void counter, however any DNS lookup that results in a non-successful RCODE 3 (nxdomain) should increment the count.

The background that led me to create this PR.

In December we saw a large spike in DMARC failure reports. These reports highlighted that SPF had gone from a pass to fail. An investigation discovered that the domain in question had more than two SPF macros before a traditional series of ip4 and ip6 entries. It appeared as though a large email provider had started to do more strict SPF validation. To test the theory we moved the ip's to before the macros and the number of failure reports fell sharply.

Because we use this package to do post deployment/change verification and validation we wanted to improve the quality of tests and the strictness. We are also interested to reach out and discuss if you want us to update this PR to include all of the other lookup failures as count increments. 

Keen for feedback and thank you for all the awesome work that's already been done in this package.

   