### PR TITLE
The RFC suggests SPF records have a record size.

### DIFF
--- a/spf_test.go
+++ b/spf_test.go
@@ -671,3 +671,25 @@ func TestWithTraceFunc(t *testing.T) {
 		t.Errorf("expected >0 trace function calls, got 0")
 	}
 }
+
+func TestOctetSizeLimit(t *testing.T) {
+	dns := NewDefaultResolver()
+	dns.Txt["domain"] = []string{"v=spf1 ip4:192.168.168.0/24 ip4:192.168.169.0/24 ip4:192.168.170.0/24 ip4:192.168.171.0/24 ip4:192.168.172.0/24 ip4:192.168.173.0/24 ip4:192.168.174.0/24 ip4:192.168.175.0/24 ip4:192.168.176.0/24 ip4:192.168.177.0/24 ip4:192.168.178.0/24 ip4:192.168.179.0/24 ip4:192.168.180.0/24 ip4:192.168.181.0/24 ip4:192.168.182.0/24 ip4:192.168.183.0/24 ip4:192.168.184.0/24 ip4:192.168.185.0/24 ip4:192.168.186.0/24 ip4:192.168.187.0/24 ip4:192.168.188.0/24 ip4:192.168.189.0/24 ip4:192.168.190.0/24 ~all"}
+	defaultTrace = t.Logf
+
+	res, err := CheckHost(ip1111, "domain")
+	if res != PermError && err != ErrOctetLimitReached {
+		t.Errorf("expected permerror, got %v (%v)", res, err)
+	}
+}
+
+func TestOverrideOctetSizeLimit(t *testing.T) {
+	dns := NewDefaultResolver()
+	dns.Txt["domain"] = []string{"v=spf1 ip4:1.1.1.1 ip4:192.168.169.0/24 ip4:192.168.170.0/24 ip4:192.168.171.0/24 ip4:192.168.172.0/24 ip4:192.168.173.0/24 ip4:192.168.174.0/24 ip4:192.168.175.0/24 ip4:192.168.176.0/24 ip4:192.168.177.0/24 ip4:192.168.178.0/24 ip4:192.168.179.0/24 ip4:192.168.180.0/24 ip4:192.168.181.0/24 ip4:192.168.182.0/24 ip4:192.168.183.0/24 ip4:192.168.184.0/24 ip4:192.168.185.0/24 ip4:192.168.186.0/24 ip4:192.168.187.0/24 ip4:192.168.188.0/24 ip4:192.168.189.0/24 ip4:192.168.190.0/24 ~all"}
+	defaultTrace = t.Logf
+
+	res, err := CheckHostWithSender(ip1111, "helo", "user@domain", OverrideOctetLimit(500))
+	if res != Pass {
+		t.Errorf("expected permerror, got %v (%v)", res, err)
+	}
+}


### PR DESCRIPTION
The RFC suggests SPF records have a record size. The default suggested limit is 450 octets.

> Similarly, the sizes for replies to all queries  related
> to SPF have to be evaluated to fit in a single 512-octet UDP
> packet (i.e., DNS message size limited to 450 octets).

This proposed change introduces a 450 octet limit check
with an optional override.

Reference RFC : [RFC 7208 Section 3.4](https://datatracker.ietf.org/doc/html/rfc7208#section-3.4)

I am using len() on the TXT record as the RFC states that the response packet [MUST be ASCII](https://datatracker.ietf.org/doc/html/rfc7208#section-3.1). If future versions of SPF move to unicode support the length calculation will need to be updated.