### PR TITLE
continue on DNS response contained records which contain invalid name

### DIFF
--- a/spf.go
+++ b/spf.go
@@ -789,7 +789,7 @@ func (r *resolution) mxField(res Result, field, domain string) (bool, Result, er
 	r.count++
 	mxs, err := r.resolver.LookupMX(r.ctx, mxDomain)
 	r.checkVoidLookup(len(mxs), err)
-	if err != nil {
+	if err != nil && len(mxs) == 0 {
 		// https://tools.ietf.org/html/rfc7208#section-5
 		if isTemporary(err) {
 			return true, TempError, err


### PR DESCRIPTION
In case if you have an spf record ```"v=spf1 mx -all"``` and the MX lookup contains valid domains and also a IP Address e.g.

```
IN	MX	20 1.1.2.2.
IN	MX	10 mailgw01.example.com.
IN	MX	200 mailgw02.example.com.
```

Golang net.Resolver will return an error and also valid mxs. In this case we could ignore the error and continue with the valid records


