### PR TITLE
grouped test ip address vars into a single var block

### DIFF
--- a/spf_test.go
+++ b/spf_test.go
@@ -21,10 +21,12 @@ func init() {
 	NewDefaultResolver()
 }
 
-var ip1110 = net.ParseIP("1.1.1.0")
-var ip1111 = net.ParseIP("1.1.1.1")
-var ip6666 = net.ParseIP("2001:db8::68")
-var ip6660 = net.ParseIP("2001:db8::0")
+var (
+	ip1110 = net.ParseIP("1.1.1.0")
+	ip1111 = net.ParseIP("1.1.1.1")
+	ip6666 = net.ParseIP("2001:db8::68")
+	ip6660 = net.ParseIP("2001:db8::0")
+)
 
 func TestBasic(t *testing.T) {
 	dns := NewDefaultResolver()


### PR DESCRIPTION
Grouped related IP test address variables into a single var block for improved readability and consistency.

This change aligns with the formatting used elsewhere in the codebase.  No functional changes